### PR TITLE
Fix issues with version handler

### DIFF
--- a/.github/workflows/version.yaml
+++ b/.github/workflows/version.yaml
@@ -9,8 +9,8 @@ permissions:
   pull-requests: write
 
 jobs:
-  create-pr:
-    name: update with PR
+  update-version:
+    name: Update workshop version
     runs-on: ubuntu-24.04
     steps:
       - name: checkout
@@ -18,8 +18,35 @@ jobs:
         with:
          fetch-depth: 0
 
-      - name: check branch exists
-        id: check
+      - name: set user profile
+        run: |
+          git config --global user.name 'jimboid'
+          git config --global user.email 'jimboid@users.noreply.github.com'
+
+      - name: update json
+        run: |  
+          jq --arg a "${{ github.event.client_payload.tag }}" '.containers."${{ github.event.client_payload.repo }}".latest = ($a)' workshop.json | jq "." | cat > workshop2.json; mv workshop2.json workshop.json
+
+      - name: log the change
+        run: |
+          cat workshop.json
+
+      - name: push changes
+        run: |
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "no changes detected"
+          else
+            if [ -z "$(git branch --list version-updates)" ]; then
+              git checkout -b version-updates
+            else
+              git checkout version-updates
+            fi
+            git commit -am "update ${{ github.event.client_payload.repo }} version to ${{ github.event.client_payload.tag }}"
+            git push
+          fi
+
+      - name: check pr exists
+        id: checkpr
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -34,29 +61,8 @@ jobs:
             echo "exists=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: checkout branch
-        if: 'steps.check.outputs.exists'
-        run: |
-          git config --global user.name 'jimboid'
-          git config --global user.email 'jimboid@users.noreply.github.com'
-          git checkout version-updates
-
-      - name: update version in json
-        run: |  
-          jq --arg a "${{ github.event.client_payload.tag }}" '.containers."${{ github.event.client_payload.repo }}".latest = ($a)' workshop.json | jq "." | cat > workshop2.json; mv workshop2.json workshop.json
-
-      - name: display
-        run: |
-          cat workshop.json
-
-      - name: push changes
-        if: 'steps.check.outputs.exists'
-        run: |
-          git commit -am "update ${{ github.event.client_payload.repo }} version to ${{ github.event.client_payload.tag }}"
-          git push
-
       - name: send PR
-        if: '!steps.check.outputs.exists'
+        if: '!steps.checkpr.outputs.exists'
         uses: peter-evans/create-pull-request@v7.0.9
         with:
           commit-message: Update ${{ github.event.client_payload.repo }} version to ${{ github.event.client_payload.tag }}


### PR DESCRIPTION
The action for version handling was not very robust. Something changed with GH commands that broke it, so this is a good opportunity to fix other things at the same time.

* We now check if the PR exists at all and then create it if not.
* We now check if the branch exists and either check it out or create it
* We now check if there has been any change to the repository and skip if not