### PR TITLE
Fix remote issue

### DIFF
--- a/.github/workflows/version.yaml
+++ b/.github/workflows/version.yaml
@@ -44,7 +44,7 @@ jobs:
             fi
             git add .
             git commit -am "update ${{ github.event.client_payload.repo }} version to ${{ github.event.client_payload.tag }}"
-            if [ -z "$(git branch --list version-updates)" ]; then
+            if [ -z "$(git ls-remote --heads origin version-updates)" ]; then
               git push --set-upstream origin version-updates
             else
               git push


### PR DESCRIPTION
If check was entering wrong state because a local check would evaluate true due to branch being created in previous step. Checking on remote is much more effective!