### PR TITLE
Add turnstyle

### DIFF
--- a/.github/workflows/version.yaml
+++ b/.github/workflows/version.yaml
@@ -13,6 +13,10 @@ jobs:
     name: Update workshop version
     runs-on: ubuntu-24.04
     steps:
+
+      - name: Turnstyle
+        uses: softprops/turnstyle@v3.2.1
+
       - name: checkout
         uses: actions/checkout@v6.0.0
         with:


### PR DESCRIPTION
Sometimes PRs are submitted for multiple repos at the same time resulting in changed ref errors and having to repeat CI. Turnstyle should get around this by implementing a queue.
